### PR TITLE
fix: Fix chat page authentication redirect loop

### DIFF
--- a/6_Agent_Deployment/frontend/src/App.tsx
+++ b/6_Agent_Deployment/frontend/src/App.tsx
@@ -11,7 +11,6 @@ import Admin from "./pages/Admin";
 import Projects from "./pages/Projects";
 import ProjectDetail from "./pages/ProjectDetail";
 import NotFound from "./pages/NotFound";
-import ProjectDetail from "./pages/ProjectDetail";
 import { AuthCallback } from "./components/auth/AuthCallback";
 import { ThemeProvider } from "@/components/theme-provider";
 import { useEffect } from "react";
@@ -50,6 +49,14 @@ const AppRoutes = () => {
       />
       <Route 
         path="/" 
+        element={
+          <ProtectedRoute>
+            <Chat />
+          </ProtectedRoute>
+        } 
+      />
+      <Route 
+        path="/chat" 
         element={
           <ProtectedRoute>
             <Chat />


### PR DESCRIPTION
## Summary

This PR fixes the authentication redirect loop that occurred when trying to access the chat page.

## Changes

- Removed duplicate `ProjectDetail` import in `App.tsx`
- Added `/chat` route that renders the Chat component with proper authentication protection
- Both `/` and `/chat` routes now show the same Chat component

## Issue Fixed

Resolves #25 - The redirect loop was caused by the missing `/chat` route definition. When users clicked on "chat" in the sidebar, it would attempt to navigate to a non-existent route, triggering authentication redirects.

Generated with [Claude Code](https://claude.ai/code)